### PR TITLE
standalone editor component

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,4 +1,5 @@
 {
   "singleQuote": true,
-  "trailingComma": "none"
+  "trailingComma": "none",
+  "printWidth": 150
 }

--- a/README.md
+++ b/README.md
@@ -20,10 +20,10 @@ npm install @ngstack/code-editor
 Import `CodeEditorModule` into your main application module:
 
 ```ts
-import { CodeEditorModule } from '@ngstack/code-editor';
+import { provideCodeEditor } from '@ngstack/code-editor';
 
 @NgModule({
-  imports: [CodeEditorModule.forRoot()]
+  providers: [provideCodeEditor()]
 })
 export class AppModule {}
 ```
@@ -34,9 +34,11 @@ If not provided, the component is always going to use the `latest` version.
 > For a full list of Monaco versions and changes, please refer to the official [CHANGELOG.md](https://github.com/microsoft/monaco-editor/blob/main/CHANGELOG.md) file
 
 ```ts
+import { provideCodeEditor } from '@ngstack/code-editor';
+
 @NgModule({
-  imports: [
-    CodeEditorModule.forRoot({
+  providers: [
+    provideCodeEditor({
       editorVersion: '0.44.0'
     })
   ]
@@ -78,7 +80,7 @@ export class AppComponent {
 ## Input Properties
 
 | Name      | Type      | Default Value | Description                                                    |
-| --------- | --------- | ------------- | -------------------------------------------------------------- |
+|-----------|-----------|---------------|----------------------------------------------------------------|
 | theme     | string    | vs            | Editor theme. Supported values: `vs`, `vs-dark` or `hc-black`. |
 | options   | Object    | {...}         | Editor options.                                                |
 | readOnly  | boolean   | false         | Toggles readonly state of the editor.                          |
@@ -297,11 +299,11 @@ Update the `angular.json` file and append the following asset rule:
 Update the main application module and setup the service to use the custom `baseUrl` when application starts:
 
 ```ts
-import { CodeEditorModule } from '@ngstack/code-editor';
+import { provideCodeEditor } from '@ngstack/code-editor';
 
 @NgModule({
-  imports: [
-    CodeEditorModule.forRoot({
+  providers: [
+    provideCodeEditor({
       baseUrl: 'assets/monaco'
     })
   ]
@@ -324,9 +326,11 @@ Update the `angular.json` file and append the following asset rule:
 Then update the `CodeEditorService` configuration at the application startup:
 
 ```ts
+import { provideCodeEditor } from '@ngstack/code-editor';
+
 @NgModule({
-  imports: [
-    CodeEditorModule.forRoot({
+  providers: [
+    provideCodeEditor({
       typingsWorkerUrl: 'assets/workers/typings-worker.js'
     })
   ]
@@ -338,6 +342,6 @@ export class AppModule {}
 
 To enable Lazy Loading
 use `CodeEditorModule.forRoot()` in the main application,
-and `CodeEditorModule.forChild()` in all lazy-loaded feature modules.
+and `CodeEditorModule` in all lazy-loaded feature modules.
 
 For more details please refer to [Lazy Loading Feature Modules](https://angular.io/guide/lazy-loading-ngmodules)

--- a/angular.json
+++ b/angular.json
@@ -57,8 +57,8 @@
               "budgets": [
                 {
                   "type": "initial",
-                  "maximumWarning": "2.41MB",
-                  "maximumError": "2.5MB"
+                  "maximumWarning": "2.8MB",
+                  "maximumError": "3MB"
                 },
                 {
                   "type": "anyComponentStyle",

--- a/package-lock.json
+++ b/package-lock.json
@@ -45,6 +45,7 @@
         "karma-jasmine": "~5.1.0",
         "karma-jasmine-html-reporter": "^2.1.0",
         "ng-packagr": "^18.1.0",
+        "prettier": "^3.3.3",
         "typescript": "5.5.4"
       }
     },
@@ -12501,6 +12502,21 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier": {
+      "version": "3.3.3",
+      "resolved": "https://registry.npmjs.org/prettier/-/prettier-3.3.3.tgz",
+      "integrity": "sha512-i2tDNA0O5IrMO757lfrdQZCc2jPNDVntV0m/+4whiDfWaTKfMNgR7Qz0NAeGz/nRqF4m5/6CLzbP4/liHt12Ew==",
+      "dev": true,
+      "bin": {
+        "prettier": "bin/prettier.cjs"
+      },
+      "engines": {
+        "node": ">=14"
+      },
+      "funding": {
+        "url": "https://github.com/prettier/prettier?sponsor=1"
       }
     },
     "node_modules/pretty-format": {

--- a/package.json
+++ b/package.json
@@ -51,6 +51,7 @@
     "karma-jasmine": "~5.1.0",
     "karma-jasmine-html-reporter": "^2.1.0",
     "ng-packagr": "^18.1.0",
+    "prettier": "^3.3.3",
     "typescript": "5.5.4"
   }
 }

--- a/projects/code-editor/src/lib/code-editor.module.spec.ts
+++ b/projects/code-editor/src/lib/code-editor.module.spec.ts
@@ -1,7 +1,0 @@
-import { CodeEditorModule } from './code-editor.module';
-
-describe('CodeEditorModule', () => {
-  it('should work', () => {
-    expect(new CodeEditorModule()).toBeDefined();
-  });
-});

--- a/projects/code-editor/src/lib/code-editor.module.ts
+++ b/projects/code-editor/src/lib/code-editor.module.ts
@@ -1,23 +1,35 @@
-import { NgModule, ModuleWithProviders, APP_INITIALIZER } from '@angular/core';
+import { APP_INITIALIZER, ModuleWithProviders, NgModule, Provider } from '@angular/core';
 import { CommonModule } from '@angular/common';
 import { CodeEditorComponent } from './code-editor/code-editor.component';
-import {
-  CodeEditorService,
-  EDITOR_SETTINGS,
-} from './services/code-editor.service';
+import { CodeEditorService, EDITOR_SETTINGS } from './services/code-editor.service';
+import { CodeEditorSettings } from './editor-settings';
 import { TypescriptDefaultsService } from './services/typescript-defaults.service';
 import { JavascriptDefaultsService } from './services/javascript-defaults.service';
-import { CodeEditorSettings } from './editor-settings';
 import { JsonDefaultsService } from './services/json-defaults.service';
 
 export function setupEditorService(service: CodeEditorService) {
-  const result = () => service.loadEditor();
-  return result;
+  return () => service.loadEditor();
 }
 
+export function provideCodeEditor(settings?: CodeEditorSettings): Provider[] {
+  return [
+    { provide: EDITOR_SETTINGS, useValue: settings },
+    CodeEditorService,
+    TypescriptDefaultsService,
+    JavascriptDefaultsService,
+    JsonDefaultsService,
+    {
+      provide: APP_INITIALIZER,
+      useFactory: setupEditorService,
+      deps: [CodeEditorService],
+      multi: true,
+    },
+  ];
+}
+
+/** @deprecated use `provideCodeEditor(settings)` instead */
 @NgModule({
-  imports: [CommonModule],
-  declarations: [CodeEditorComponent],
+  imports: [CommonModule, CodeEditorComponent],
   exports: [CodeEditorComponent],
 })
 export class CodeEditorModule {
@@ -29,9 +41,6 @@ export class CodeEditorModule {
       providers: [
         { provide: EDITOR_SETTINGS, useValue: settings },
         CodeEditorService,
-        TypescriptDefaultsService,
-        JavascriptDefaultsService,
-        JsonDefaultsService,
         {
           provide: APP_INITIALIZER,
           useFactory: setupEditorService,
@@ -39,12 +48,6 @@ export class CodeEditorModule {
           multi: true,
         },
       ],
-    };
-  }
-
-  static forChild(): ModuleWithProviders<CodeEditorModule> {
-    return {
-      ngModule: CodeEditorModule,
     };
   }
 }

--- a/projects/code-editor/src/lib/code-editor/code-editor.component.spec.ts
+++ b/projects/code-editor/src/lib/code-editor/code-editor.component.spec.ts
@@ -2,9 +2,7 @@ import { ComponentFixture, TestBed, fakeAsync } from '@angular/core/testing';
 
 import { CodeEditorComponent } from './code-editor.component';
 import { CodeEditorService } from '../services/code-editor.service';
-import { TypescriptDefaultsService } from '../services/typescript-defaults.service';
-import { JavascriptDefaultsService } from '../services/javascript-defaults.service';
-import { CodeEditorModule } from '../code-editor.module';
+import { provideCodeEditor } from '../code-editor.module';
 
 describe('CodeEditorComponent', () => {
   let component: CodeEditorComponent;
@@ -13,12 +11,7 @@ describe('CodeEditorComponent', () => {
 
   beforeEach(() => {
     TestBed.configureTestingModule({
-      imports: [CodeEditorModule.forRoot({ baseUrl: 'assets/monaco' })],
-      providers: [
-        CodeEditorService,
-        TypescriptDefaultsService,
-        JavascriptDefaultsService
-      ]
+      imports: [provideCodeEditor({ baseUrl: 'assets/monaco' })]
     });
 
     codeEditorService = TestBed.inject(CodeEditorService);

--- a/projects/code-editor/src/lib/code-editor/code-editor.component.ts
+++ b/projects/code-editor/src/lib/code-editor/code-editor.component.ts
@@ -29,6 +29,7 @@ export interface CodeModelChangedEvent {
 @Component({
   // eslint-disable-next-line @angular-eslint/component-selector
   selector: 'ngs-code-editor',
+  standalone: true,
   templateUrl: './code-editor.component.html',
   styleUrls: ['./code-editor.component.css'],
   changeDetection: ChangeDetectionStrategy.OnPush,

--- a/projects/multiple-editors/src/app/app.module.ts
+++ b/projects/multiple-editors/src/app/app.module.ts
@@ -1,21 +1,19 @@
 import { BrowserModule } from '@angular/platform-browser';
 import { NgModule } from '@angular/core';
-import { CodeEditorModule } from '@ngstack/code-editor';
-
+import { provideCodeEditor } from '@ngstack/code-editor';
 import { AppComponent } from './app.component';
 
 @NgModule({
   declarations: [AppComponent],
-  imports: [
-    BrowserModule,
-    CodeEditorModule.forRoot({
+  imports: [BrowserModule],
+  providers: [
+    provideCodeEditor({
       // use local Monaco installation
       baseUrl: 'assets/monaco',
       // use local Typings Worker
-      typingsWorkerUrl: 'assets/workers/typings-worker.js',
-    }),
+      typingsWorkerUrl: 'assets/workers/typings-worker.js'
+    })
   ],
-  providers: [],
-  bootstrap: [AppComponent],
+  bootstrap: [AppComponent]
 })
 export class AppModule {}

--- a/src/app/app.module.ts
+++ b/src/app/app.module.ts
@@ -1,7 +1,7 @@
 import { NgModule } from '@angular/core';
 import { BrowserModule } from '@angular/platform-browser';
 import { RouterModule, Route } from '@angular/router';
-import { CodeEditorModule } from '@ngstack/code-editor';
+import { provideCodeEditor } from '@ngstack/code-editor';
 import { AppComponent } from './app.component';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
 import { CodeEditorDemoComponent } from './code-editor-demo/code-editor-demo.component';
@@ -20,14 +20,16 @@ const routes: Route[] = [
     RouterModule.forRoot(routes, {
       initialNavigation: 'enabledBlocking'
     }),
-    CodeEditorModule.forRoot({
+    CodeEditorDemoComponent
+  ],
+  providers: [
+    provideCodeEditor({
       // editorVersion: '0.46.0',
       // use local Monaco installation
       baseUrl: 'assets/monaco',
       // use local Typings Worker
       typingsWorkerUrl: 'assets/workers/typings-worker.js'
-    }),
-    CodeEditorDemoComponent
+    })
   ],
   declarations: [AppComponent],
   bootstrap: [AppComponent]

--- a/src/app/code-editor-demo/code-editor-demo.component.spec.ts
+++ b/src/app/code-editor-demo/code-editor-demo.component.spec.ts
@@ -1,9 +1,8 @@
 import { ComponentFixture, TestBed, waitForAsync } from '@angular/core/testing';
 
 import { CodeEditorDemoComponent } from './code-editor-demo.component';
-import { CodeEditorModule } from '@ngstack/code-editor';
+import { provideCodeEditor } from '@ngstack/code-editor';
 import { BrowserAnimationsModule } from '@angular/platform-browser/animations';
-import { MaterialModule } from '../material.module';
 
 describe('CodeEditorDemoComponent', () => {
   let component: CodeEditorDemoComponent;
@@ -11,12 +10,8 @@ describe('CodeEditorDemoComponent', () => {
 
   beforeEach(waitForAsync(() => {
     TestBed.configureTestingModule({
-      imports: [
-        BrowserAnimationsModule,
-        MaterialModule,
-        CodeEditorModule.forRoot()
-      ],
-      declarations: [CodeEditorDemoComponent]
+      imports: [BrowserAnimationsModule, CodeEditorDemoComponent],
+      providers: [provideCodeEditor()]
     }).compileComponents();
   }));
 

--- a/src/app/code-editor-demo/code-editor-demo.component.ts
+++ b/src/app/code-editor-demo/code-editor-demo.component.ts
@@ -1,17 +1,5 @@
-import {
-  Component,
-  HostBinding,
-  OnInit,
-  ViewChild,
-  ViewEncapsulation
-} from '@angular/core';
-import {
-  CodeEditorComponent,
-  CodeEditorModule,
-  CodeEditorService,
-  CodeModel,
-  CodeModelChangedEvent
-} from '@ngstack/code-editor';
+import { Component, HostBinding, OnInit, ViewChild, ViewEncapsulation } from '@angular/core';
+import { CodeEditorComponent, CodeEditorService, CodeModel, CodeModelChangedEvent } from '@ngstack/code-editor';
 import { Observable } from 'rxjs';
 import { debounceTime } from 'rxjs/operators';
 import { FileDatabase } from './file-database';
@@ -37,11 +25,11 @@ import { MatOption, MatSelect, MatSelectChange } from '@angular/material/select'
     MatMenuModule,
     MatIconModule,
     MatProgressBarModule,
-    CodeEditorModule,
     MatFormField,
     MatSelect,
     MatOption,
     MatLabel,
+    CodeEditorComponent
   ],
   selector: 'app-code-editor-demo',
   templateUrl: './code-editor-demo.component.html',
@@ -87,13 +75,11 @@ export class CodeEditorDemoComponent implements OnInit {
   selectedFile: FileNode;
 
   constructor(database: FileDatabase, editorService: CodeEditorService) {
-    database.dataChange.subscribe(
-      (data) => {
-        this.files = data;
-        this.selectedFile = this.files[0];
-        this.selectNode(this.selectedFile);
-      }
-    );
+    database.dataChange.subscribe((data) => {
+      this.files = data;
+      this.selectedFile = this.files[0];
+      this.selectNode(this.selectedFile);
+    });
 
     this.isLoading$ = editorService.loadingTypings.pipe(debounceTime(300));
   }


### PR DESCRIPTION
- migrate to standalone component
 - introduce `provideCodeEditor` function instead of the module
 - update application